### PR TITLE
MTGチェックボックス分集計範囲をずらす

### DIFF
--- a/scripts/workTimeTotals/src/domain/workEntry/WorkEntry.ts
+++ b/scripts/workTimeTotals/src/domain/workEntry/WorkEntry.ts
@@ -7,7 +7,8 @@ interface WorkEntryProps {
   endTime: string;
   mainCategory: string;
   subCategory: string;
-  description: string;
+  meeting?: string;
+  workContent: string;
 }
 
 export class WorkEntry {
@@ -16,7 +17,8 @@ export class WorkEntry {
   private readonly _endTime: string;
   private readonly _mainCategory: string;
   private readonly _subCategory: string;
-  private readonly _description: string;
+  private readonly _meeting: string;
+  private readonly _workContent: string;
 
   constructor(props: WorkEntryProps) {
     this.validateProps(props);
@@ -26,7 +28,8 @@ export class WorkEntry {
     this._endTime = props.endTime;
     this._mainCategory = props.mainCategory;
     this._subCategory = props.subCategory;
-    this._description = props.description;
+    this._meeting = props.meeting || '';
+    this._workContent = props.workContent;
   }
 
   private validateProps(props: WorkEntryProps): void {
@@ -157,7 +160,7 @@ export class WorkEntry {
           cellData: {
             row: 0,
             values: [props.date, props.startTime, props.endTime, props.mainCategory, props.subCategory],
-            expectedFormat: '日付 | 開始時刻 | 終了時刻 | メインカテゴリ | サブカテゴリ | 説明'
+            expectedFormat: '日付 | 開始時刻 | 終了時刻 | メインカテゴリ | サブカテゴリ | MTG | 業務内容'
           }
         }
       );
@@ -184,7 +187,15 @@ export class WorkEntry {
   get subCategory(): string {
     return this._subCategory;
   }
+  get meeting(): string {
+    return this._meeting;
+  }
+  get workContent(): string {
+    return this._workContent;
+  }
+  
+  // 後方互換性のために残す
   get description(): string {
-    return this._description;
+    return this._workContent;
   }
 }

--- a/scripts/workTimeTotals/src/domain/workEntry/WorkEntryRepository.ts
+++ b/scripts/workTimeTotals/src/domain/workEntry/WorkEntryRepository.ts
@@ -79,20 +79,64 @@ export class WorkEntryRepository implements WorkEntryRepositoryInterface {
 
   findAll(): WorkEntryCollection {
     try {
-      const values = this.adapter.getValues('I3:N');
+      const values = this.adapter.getValues('J3:P');
       const entries = new WorkEntryCollection();
 
       values.forEach((row, index) => {
         try {
           if (!row[0] && !row[1] && !row[2]) return;
 
+          // デバッグログを追加して行データの構造を確認
+          console.log(`デバッグ: 行${index + 3}の値:`, JSON.stringify(row, (key, value) => {
+            if (value instanceof Date) {
+              return `Date(${value.toISOString()})`;
+            }
+            return value;
+          }));
+
+          // データ型の処理を改善
+          let dateValue = row[0];
+          let startTimeValue = row[1];
+          let endTimeValue = row[2];
+
+          // 日付の処理
+          let date;
+          if (dateValue instanceof Date) {
+            date = dateValue;
+          } else if (typeof dateValue === 'string') {
+            try {
+              // 文字列から日付への変換を試みる
+              date = new Date(dateValue);
+              if (isNaN(date.getTime())) {
+                throw new Error(`Invalid date string: ${dateValue}`);
+              }
+            } catch (e) {
+              console.error(`日付変換エラー: ${e}`, dateValue);
+              // デフォルトの日付を使用（シート名から）
+              date = this.extractDateFromSheetName();
+            }
+          } else {
+            console.warn(`未知の日付フォーマット: ${typeof dateValue}`, dateValue);
+            date = this.extractDateFromSheetName();
+          }
+
+          // 時刻の処理
+          const startTime = startTimeValue instanceof Date 
+            ? this.formatTime(startTimeValue) 
+            : startTimeValue?.toString() || '';
+          
+          const endTime = endTimeValue instanceof Date 
+            ? this.formatTime(endTimeValue) 
+            : endTimeValue?.toString() || '';
+
           const entry = new WorkEntry({
-            date: row[0],
-            startTime: row[1] instanceof Date ? this.formatTime(row[1]) : row[1],
-            endTime: row[2] instanceof Date ? this.formatTime(row[2]) : row[2],
+            date,
+            startTime,
+            endTime,
             mainCategory: row[3]?.toString() || '',
             subCategory: row[4]?.toString() || '',
-            description: row[5]?.toString() || ''
+            meeting: row[5]?.toString() || '',
+            workContent: row[6]?.toString() || ''
           });
           entries.add(entry);
         } catch (error) {
@@ -104,7 +148,7 @@ export class WorkEntryRepository implements WorkEntryRepositoryInterface {
               cellData: {
                 row: index + 3,
                 values: row,
-                expectedFormat: '日付 | 開始時刻 | 終了時刻 | メインカテゴリ | サブカテゴリ | 説明'
+                expectedFormat: '日付 | 開始時刻 | 終了時刻 | メインカテゴリ | サブカテゴリ | MTG | 業務内容'
               },
               // 元のエラーの詳細情報も保持
               originalError: error.details
@@ -141,5 +185,33 @@ export class WorkEntryRepository implements WorkEntryRepositoryInterface {
     const hours = date.getHours().toString().padStart(2, '0');
     const minutes = date.getMinutes().toString().padStart(2, '0');
     return `${hours}:${minutes}`;
+  }
+
+  // シート名から日付を抽出するメソッドを追加
+  private extractDateFromSheetName(): Date {
+    try {
+      const sheetName = this.adapter.sheetName;
+      if (!/^\d{8}$/.test(sheetName)) {
+        throw new Error(`シート名が日付形式ではありません: ${sheetName}`);
+      }
+      
+      const year = parseInt(sheetName.substring(0, 4), 10);
+      const month = parseInt(sheetName.substring(4, 6), 10) - 1; // JavaScriptの月は0-11
+      const day = parseInt(sheetName.substring(6, 8), 10);
+      
+      const date = new Date(year, month, day);
+      
+      if (isNaN(date.getTime())) {
+        throw new Error(`無効な日付です: ${sheetName}`);
+      }
+      
+      return date;
+    } catch (error) {
+      throw new WorktimeError(
+        `シート名から日付を抽出できませんでした: ${this.adapter.sheetName}`,
+        ErrorCodes.INVALID_SHEET_FORMAT,
+        error
+      );
+    }
   }
 } 

--- a/scripts/workTimeTotals/src/main.ts
+++ b/scripts/workTimeTotals/src/main.ts
@@ -183,7 +183,21 @@ function main() {
     worktimeOutput.visualizeOvertimeAndCategory(overtimeSummaries, entriesForOvertime);
 
     // 案件別作業時間の内訳を出力
-    worktimeOutput.visualizeProjectBreakdown(entriesForOvertime);
+    // Filter entries by the target main categories before visualization
+    const projectFilteredEntries = new Map<string, WorkEntry[]>();
+
+    entriesForOvertime.forEach((entries, name) => {
+      // Filter entries that belong to the target projects (main categories)
+      const filteredEntries = entries.filter(entry =>
+        targetMainCategories.includes(entry.mainCategory)
+      );
+
+      if (filteredEntries.length > 0) {
+        projectFilteredEntries.set(name, filteredEntries);
+      }
+    });
+
+    worktimeOutput.visualizeProjectBreakdown(projectFilteredEntries);
 
   } catch (error) {
     if (error instanceof WorktimeError) {

--- a/scripts/workTimeTotals/test/application/CategoryTotalingService.test.ts
+++ b/scripts/workTimeTotals/test/application/CategoryTotalingService.test.ts
@@ -17,7 +17,8 @@ describe('CategoryTotalingService', () => {
           endTime: '12:00', // 3時間
           mainCategory: 'WEB開発',
           subCategory: 'コーディング',
-          description: 'タスク1'
+          meeting: '',
+          workContent: 'タスク1'
         }),
         new WorkEntry({
           date: new Date('2024/03/01'),
@@ -25,7 +26,8 @@ describe('CategoryTotalingService', () => {
           endTime: '17:00', // 4時間
           mainCategory: '運用',
           subCategory: '定例作業',
-          description: 'タスク2'
+          meeting: '',
+          workContent: 'タスク2'
         })
       ]);
 
@@ -37,7 +39,8 @@ describe('CategoryTotalingService', () => {
           endTime: '18:00', // 9時間
           mainCategory: 'WEB開発',
           subCategory: 'テスト',
-          description: 'タスク3'
+          meeting: '',
+          workContent: 'タスク3'
         })
       ]);
 
@@ -75,7 +78,8 @@ describe('CategoryTotalingService', () => {
           endTime: '12:00', // 3時間
           mainCategory: 'WEB開発',
           subCategory: 'コーディング',
-          description: 'タスク1'
+          meeting: '',
+          workContent: 'タスク1'
         }),
         new WorkEntry({
           date: new Date('2024/03/01'),
@@ -83,7 +87,8 @@ describe('CategoryTotalingService', () => {
           endTime: '13:00', // 1時間（休憩）
           mainCategory: '休憩',
           subCategory: '休憩',
-          description: 'お昼休憩'
+          meeting: '',
+          workContent: 'お昼休憩'
         })
       ]);
 

--- a/scripts/workTimeTotals/test/application/OvertimeCalculationService.test.ts
+++ b/scripts/workTimeTotals/test/application/OvertimeCalculationService.test.ts
@@ -17,7 +17,8 @@ describe('OvertimeCalculationService', () => {
           endTime: '18:00', // 1時間の残業
           mainCategory: 'WEB開発',
           subCategory: 'コーディング',
-          description: 'タスク1'
+          meeting: '',
+          workContent: 'タスク1'
         }),
         new WorkEntry({
           date: new Date('2024/03/08'),
@@ -25,7 +26,8 @@ describe('OvertimeCalculationService', () => {
           endTime: '19:00', // 2時間の残業
           mainCategory: 'WEB開発',
           subCategory: 'テスト',
-          description: 'タスク2'
+          meeting: '',
+          workContent: 'タスク2'
         })
       ]);
 
@@ -37,7 +39,8 @@ describe('OvertimeCalculationService', () => {
           endTime: '20:00', // 3時間の残業
           mainCategory: 'WEB開発',
           subCategory: 'コーディング',
-          description: 'タスク3'
+          meeting: '',
+          workContent: 'タスク3'
         })
       ]);
 

--- a/scripts/workTimeTotals/test/application/SubCategoryTotalingService.test.ts
+++ b/scripts/workTimeTotals/test/application/SubCategoryTotalingService.test.ts
@@ -17,7 +17,8 @@ describe('SubCategoryTotalingService', () => {
           endTime: '12:00', // 3時間
           mainCategory: 'WEB開発',
           subCategory: 'コーディング',
-          description: 'タスク1'
+          meeting: '',
+          workContent: 'タスク1'
         }),
         new WorkEntry({
           date: new Date('2024/03/01'),
@@ -25,7 +26,8 @@ describe('SubCategoryTotalingService', () => {
           endTime: '17:00', // 4時間
           mainCategory: 'WEB開発',
           subCategory: 'テスト',
-          description: 'タスク2'
+          meeting: '',
+          workContent: 'タスク2'
         })
       ]);
 
@@ -37,7 +39,8 @@ describe('SubCategoryTotalingService', () => {
           endTime: '18:00', // 9時間
           mainCategory: 'WEB開発',
           subCategory: 'コーディング',
-          description: 'タスク3'
+          meeting: '',
+          workContent: 'タスク3'
         })
       ]);
 
@@ -79,7 +82,8 @@ describe('SubCategoryTotalingService', () => {
           endTime: '12:00', // 3時間
           mainCategory: 'WEB開発',
           subCategory: 'コーディング',
-          description: 'タスク1'
+          meeting: '',
+          workContent: 'タスク1'
         }),
         new WorkEntry({
           date: new Date('2024/03/01'),
@@ -87,7 +91,8 @@ describe('SubCategoryTotalingService', () => {
           endTime: '17:00', // 4時間
           mainCategory: '学習',
           subCategory: 'コーディング',
-          description: 'タスク2'
+          meeting: '',
+          workContent: 'タスク2'
         })
       ]);
 

--- a/scripts/workTimeTotals/test/domain/category/CategoryCalculator.test.ts
+++ b/scripts/workTimeTotals/test/domain/category/CategoryCalculator.test.ts
@@ -12,7 +12,8 @@ describe('CategoryCalculator', () => {
           endTime: '12:00', // 3時間
           mainCategory: 'WEB開発',
           subCategory: 'コーディング',
-          description: 'タスク1'
+          meeting: '',
+          workContent: 'タスク1'
         }),
         new WorkEntry({
           date: new Date('2024/03/01'),
@@ -20,7 +21,8 @@ describe('CategoryCalculator', () => {
           endTime: '17:00', // 4時間
           mainCategory: 'WEB開発',
           subCategory: 'テスト',
-          description: 'タスク2'
+          meeting: '',
+          workContent: 'タスク2'
         }),
         new WorkEntry({
           date: new Date('2024/03/01'),
@@ -28,7 +30,8 @@ describe('CategoryCalculator', () => {
           endTime: '18:00', // 1時間
           mainCategory: '運用',
           subCategory: '定例作業',
-          description: 'タスク3'
+          meeting: '',
+          workContent: 'タスク3'
         })
       ];
 
@@ -45,7 +48,8 @@ describe('CategoryCalculator', () => {
           endTime: '12:00', // 3時間
           mainCategory: 'WEB開発',
           subCategory: 'コーディング',
-          description: 'タスク1'
+          meeting: '',
+          workContent: 'タスク1'
         }),
         new WorkEntry({
           date: new Date('2024/03/01'),
@@ -53,7 +57,8 @@ describe('CategoryCalculator', () => {
           endTime: '13:00', // 1時間（休憩）
           mainCategory: '休憩',
           subCategory: '休憩',
-          description: 'お昼休憩'
+          meeting: '',
+          workContent: 'お昼休憩'
         }),
         new WorkEntry({
           date: new Date('2024/03/01'),
@@ -61,7 +66,8 @@ describe('CategoryCalculator', () => {
           endTime: '15:00', // 2時間
           mainCategory: 'WEB開発',
           subCategory: 'テスト',
-          description: 'タスク2'
+          meeting: '',
+          workContent: 'タスク2'
         })
       ];
 
@@ -78,7 +84,8 @@ describe('CategoryCalculator', () => {
           endTime: '01:00', // 3時間
           mainCategory: 'WEB開発',
           subCategory: 'コーディング',
-          description: 'タスク1'
+          meeting: '',
+          workContent: 'タスク1'
         }),
         new WorkEntry({
           date: new Date('2024/03/01'),
@@ -86,7 +93,8 @@ describe('CategoryCalculator', () => {
           endTime: '17:00', // 8時間
           mainCategory: 'WEB開発',
           subCategory: 'テスト',
-          description: 'タスク2'
+          meeting: '',
+          workContent: 'タスク2'
         })
       ];
 
@@ -104,7 +112,8 @@ describe('CategoryCalculator', () => {
           endTime: '12:00', // 3時間
           mainCategory: 'WEB開発',
           subCategory: 'コーディング',
-          description: 'タスク1'
+          meeting: '',
+          workContent: 'タスク1'
         }),
         new WorkEntry({
           date: new Date('2024/03/01'),
@@ -112,7 +121,8 @@ describe('CategoryCalculator', () => {
           endTime: '17:00', // 4時間
           mainCategory: 'WEB開発',
           subCategory: 'テスト',
-          description: 'タスク2'
+          meeting: '',
+          workContent: 'タスク2'
         }),
         new WorkEntry({
           date: new Date('2024/03/01'),
@@ -120,7 +130,8 @@ describe('CategoryCalculator', () => {
           endTime: '18:00', // 1時間
           mainCategory: '運用',
           subCategory: '定例作業',
-          description: 'タスク3'
+          meeting: '',
+          workContent: 'タスク3'
         })
       ];
 

--- a/scripts/workTimeTotals/test/domain/overtime/OvertimeCalculator.test.ts
+++ b/scripts/workTimeTotals/test/domain/overtime/OvertimeCalculator.test.ts
@@ -13,7 +13,8 @@ describe('OvertimeCalculator', () => {
           endTime: '18:00', // 1時間の残業
           mainCategory: 'WEB開発',
           subCategory: 'コーディング',
-          description: 'タスク1'
+          meeting: '',
+          workContent: 'タスク1'
         }),
         new WorkEntry({
           date: new Date('2024/03/02'),
@@ -21,7 +22,8 @@ describe('OvertimeCalculator', () => {
           endTime: '19:00', // 2時間の残業
           mainCategory: 'WEB開発',
           subCategory: 'テスト',
-          description: 'タスク2'
+          meeting: '',
+          workContent: 'タスク2'
         })
       ];
 
@@ -36,7 +38,8 @@ describe('OvertimeCalculator', () => {
           endTime: '18:00',
           mainCategory: 'WEB開発',
           subCategory: 'コーディング',
-          description: 'タスク1'
+          meeting: '',
+          workContent: 'タスク1'
         }),
         new WorkEntry({
           date: new Date('2024/03/01'),
@@ -44,7 +47,8 @@ describe('OvertimeCalculator', () => {
           endTime: '13:00',
           mainCategory: '休憩',
           subCategory: '休憩',
-          description: 'お昼休憩'
+          meeting: '',
+          workContent: 'お昼休憩'
         })
       ];
 
@@ -59,7 +63,8 @@ describe('OvertimeCalculator', () => {
           endTime: '02:00', // 翌日2時まで（7時間の作業）
           mainCategory: 'WEB開発',
           subCategory: 'コーディング',
-          description: 'タスク1'
+          meeting: '',
+          workContent: 'タスク1'
         })
       ];
 
@@ -74,7 +79,8 @@ describe('OvertimeCalculator', () => {
           endTime: '02:00', // 翌日2時まで（17時間の作業）
           mainCategory: 'WEB開発',
           subCategory: 'コーディング',
-          description: 'タスク1'
+          meeting: '',
+          workContent: 'タスク1'
         })
       ];
 
@@ -94,7 +100,8 @@ describe('OvertimeCalculator', () => {
           endTime: '18:00', // 1時間の残業
           mainCategory: 'WEB開発',
           subCategory: 'コーディング',
-          description: 'タスク1'
+          meeting: '',
+          workContent: 'タスク1'
         }),
         new WorkEntry({
           date: date2,
@@ -102,7 +109,8 @@ describe('OvertimeCalculator', () => {
           endTime: '19:00', // 2時間の残業
           mainCategory: 'WEB開発',
           subCategory: 'テスト',
-          description: 'タスク2'
+          meeting: '',
+          workContent: 'タスク2'
         })
       ];
 

--- a/scripts/workTimeTotals/test/domain/workentry/WorkEntry.test.ts
+++ b/scripts/workTimeTotals/test/domain/workentry/WorkEntry.test.ts
@@ -10,7 +10,8 @@ describe('WorkEntry', () => {
         endTime: '12:00',
         mainCategory: '学習',
         subCategory: '開発',
-        description: '技術研修 カネカ チェック項目確認作業'
+        meeting: '',
+        workContent: '技術研修 カネカ チェック項目確認作業'
       });
 
       expect(entry.date).toEqual(new Date('2025/02/12'));
@@ -18,7 +19,8 @@ describe('WorkEntry', () => {
       expect(entry.endTime).toBe('12:00');
       expect(entry.mainCategory).toBe('学習');
       expect(entry.subCategory).toBe('開発');
-      expect(entry.description).toBe('技術研修 カネカ チェック項目確認作業');
+      expect(entry.meeting).toBe('');
+      expect(entry.workContent).toBe('技術研修 カネカ チェック項目確認作業');
     });
   });
 
@@ -30,7 +32,8 @@ describe('WorkEntry', () => {
         endTime: '12:00',
         mainCategory: '学習',
         subCategory: '開発',
-        description: '技術研修 カネカ チェック項目確認作業'
+        meeting: '',
+        workContent: '技術研修 カネカ チェック項目確認作業'
       });
 
       expect(entry.calculateDuration()).toBe(2); // 2時間
@@ -43,7 +46,8 @@ describe('WorkEntry', () => {
         endTime: '01:30',
         mainCategory: '運用',
         subCategory: '障害対応',
-        description: '緊急対応'
+        meeting: '',
+        workContent: '緊急対応'
       });
 
       expect(entry.calculateDuration()).toBe(3.5); //   3時間30分 = 3.5時間
@@ -59,7 +63,8 @@ describe('WorkEntry', () => {
           endTime: '17:30',
           mainCategory: 'WEB開発',
           subCategory: 'コーディング',
-          description: 'WorkEntryクラスの実装'
+          meeting: '',
+          workContent: 'WorkEntryクラスの実装'
         });
       }).toThrow('Invalid start time format');  // エラーメッセージを更新
     });
@@ -72,7 +77,8 @@ describe('WorkEntry', () => {
           endTime: '12:00',
           mainCategory: '学習',
           subCategory: '',  // 空文字
-          description: '技術研修 カネカ チェック項目確認作業'
+          meeting: '',
+          workContent: '技術研修 カネカ チェック項目確認作業'
         });
       }).toThrow('SubCategory is required');
     });

--- a/scripts/workTimeTotals/test/domain/workentry/WorkEntryCollection.test.ts
+++ b/scripts/workTimeTotals/test/domain/workentry/WorkEntryCollection.test.ts
@@ -13,7 +13,8 @@ describe('WorkEntryCollection', () => {
         endTime: '12:00',
         mainCategory: '学習',
         subCategory: '開発',
-        description: '技術研修'
+        meeting: '',
+        workContent: '技術研修'
       });
 
       collection.add(entry);
@@ -29,7 +30,8 @@ describe('WorkEntryCollection', () => {
         endTime: '12:00',
         mainCategory: '学習',
         subCategory: '開発',
-        description: '技術研修'
+        meeting: '',
+        workContent: '技術研修'
       });
       const entry2 = new WorkEntry({
         date: new Date('2025/02/13'),
@@ -37,7 +39,8 @@ describe('WorkEntryCollection', () => {
         endTime: '15:00',
         mainCategory: '学習',
         subCategory: '開発',
-        description: '技術研修2日目'
+        meeting: '',
+        workContent: '技術研修2日目'
       });
 
       collection.add(entry1);
@@ -58,7 +61,8 @@ describe('WorkEntryCollection', () => {
         endTime: '12:00',
         mainCategory: '学習',
         subCategory: '開発',
-        description: '午前の部'
+        meeting: '',
+        workContent: '午前の部'
       }));
       collection.add(new WorkEntry({
         date: new Date('2025/02/12'),
@@ -66,7 +70,8 @@ describe('WorkEntryCollection', () => {
         endTime: '17:30',
         mainCategory: '学習',
         subCategory: '開発',
-        description: '午後の部'
+        meeting: '',
+        workContent: '午後の部'
       }));
 
       expect(collection.totalDuration()).toBe(6.5); // 2時間 + 4.5時間
@@ -80,7 +85,8 @@ describe('WorkEntryCollection', () => {
         endTime: '12:00',
         mainCategory: '学習',
         subCategory: '開発',
-        description: '技術研修'
+        meeting: '',
+        workContent: '技術研修'
       }));
       collection.add(new WorkEntry({
         date: new Date('2025/02/12'),
@@ -88,7 +94,8 @@ describe('WorkEntryCollection', () => {
         endTime: '15:00',
         mainCategory: '運用',
         subCategory: '定例作業',
-        description: '日次確認'
+        meeting: '',
+        workContent: '日次確認'
       }));
 
       const categoryTotals = collection.totalDurationByCategory();
@@ -107,7 +114,8 @@ describe('WorkEntryCollection', () => {
           endTime: '12:00',
           mainCategory: 'WEB開発',
           subCategory: 'コーディング',
-          description: 'タスク1'
+          meeting: '',
+          workContent: 'タスク1'
         }));
 
         // 休憩時間
@@ -117,7 +125,8 @@ describe('WorkEntryCollection', () => {
           endTime: '13:00',
           mainCategory: '休憩',
           subCategory: '休憩',
-          description: 'お昼休憩'
+          meeting: '',
+          workContent: 'お昼休憩'
         }));
 
         // 通常の作業
@@ -127,7 +136,8 @@ describe('WorkEntryCollection', () => {
           endTime: '17:30',
           mainCategory: 'WEB開発',
           subCategory: 'テスト',
-          description: 'タスク2'
+          meeting: '',
+          workContent: 'タスク2'
         }));
 
         expect(collection.totalDuration()).toBe(7.5); // 3時間 + 4.5時間 = 7.5時間
@@ -145,7 +155,8 @@ describe('WorkEntryCollection', () => {
           endTime: '12:00',
           mainCategory: 'WEB開発',
           subCategory: 'コーディング',
-          description: 'タスク1'
+          meeting: '',
+          workContent: 'タスク1'
         }));
 
         const totals = collection.totalDurationByCategory();
@@ -163,7 +174,8 @@ describe('WorkEntryCollection', () => {
         endTime: '00:00',
         mainCategory: 'その他',
         subCategory: '予定立て・日報',
-        description: '勤怠集計 仕様の確認'
+        meeting: '',
+        workContent: '勤怠集計 仕様の確認'
       }));
 
       expect(collection.totalDuration()).toBe(5);
@@ -176,7 +188,8 @@ describe('WorkEntryCollection', () => {
         endTime: '02:00',
         mainCategory: 'その他',
         subCategory: '予定立て・日報',
-        description: '勤怠集計 仕様の確認'
+        meeting: '',
+        workContent: '勤怠集計 仕様の確認'
       }));
 
       expect(collection2.totalDuration()).toBe(7);
@@ -194,7 +207,8 @@ describe('WorkEntryCollection', () => {
         endTime: '18:00',
         mainCategory: 'WEB開発',
         subCategory: 'コーディング',
-        description: 'タスク1'
+        meeting: '',
+        workContent: 'タスク1'
       }));
 
       expect(collection.totalOvertimeHours()).toBe(1);
@@ -210,7 +224,8 @@ describe('WorkEntryCollection', () => {
         endTime: '18:00',
         mainCategory: 'WEB開発',
         subCategory: 'コーディング',
-        description: 'タスク1'
+        meeting: '',
+        workContent: 'タスク1'
       }));
 
       // 1時間の休憩
@@ -220,7 +235,8 @@ describe('WorkEntryCollection', () => {
         endTime: '13:00',
         mainCategory: '休憩',
         subCategory: '休憩',
-        description: 'お昼休憩'
+        meeting: '',
+        workContent: 'お昼休憩'
       }));
 
       expect(collection.totalOvertimeHours()).toBe(1);
@@ -237,7 +253,8 @@ describe('WorkEntryCollection', () => {
         endTime: '18:00',
         mainCategory: 'WEB開発',
         subCategory: 'コーディング',
-        description: 'タスク1'
+        meeting: '',
+        workContent: 'タスク1'
       }));
 
       // 3/2: 2時間の残業
@@ -248,7 +265,8 @@ describe('WorkEntryCollection', () => {
         endTime: '19:00',
         mainCategory: 'WEB開発',
         subCategory: 'テスト',
-        description: 'タスク2'
+        meeting: '',
+        workContent: 'タスク2'
       }));
 
       const overtimeByDate = collection.overtimeHoursByDate();

--- a/scripts/workTimeTotals/test/domain/workentry/WorkEntryRepository.test.ts
+++ b/scripts/workTimeTotals/test/domain/workentry/WorkEntryRepository.test.ts
@@ -47,10 +47,10 @@ describe('WorkEntryRepository', () => {
 
   describe('findByDateRange', () => {
     it('指定された期間内のWorkEntryを取得できること', () => {
-      // getValuesのモックデータを設定 - I3:N の範囲のデータ形式に合わせる
+      // getValuesのモックデータを設定 - J3:P の範囲のデータ形式に合わせる
       const mockValues = [
-        [new Date('2024/03/01'), '09:00', '17:30', 'WEB開発', 'コーディング', 'タスク1'],
-        [new Date('2024/03/15'), '10:00', '18:00', 'WEB運用', '定例作業', 'タスク2']
+        [new Date('2024/03/01'), '09:00', '17:30', 'WEB開発', 'コーディング', '', 'タスク1'],
+        [new Date('2024/03/15'), '10:00', '18:00', 'WEB運用', '定例作業', '', 'タスク2']
       ];
       vi.mocked(mockAdapter.getValues).mockReturnValue(mockValues);
 
@@ -60,7 +60,7 @@ describe('WorkEntryRepository', () => {
       );
 
       expect(result.entries).toHaveLength(1);
-      expect(result.entries[0].description).toBe('タスク2');
+      expect(result.entries[0].workContent).toBe('タスク2');
     });
   });
 
@@ -73,7 +73,8 @@ describe('WorkEntryRepository', () => {
         endTime: '17:30',
         mainCategory: 'WEB開発',
         subCategory: 'コーディング',
-        description: 'タスク1'
+        meeting: '',
+        workContent: 'タスク1'
       }));
 
       repository.save(entries);
@@ -95,15 +96,15 @@ describe('WorkEntryRepository', () => {
 
   describe('findAll', () => {
     it('WorkEntriesシートからデータを取得できること', () => {
-      // getValuesのモックデータを設定 - I3:N の範囲のデータ形式に合わせる
+      // getValuesのモックデータを設定 - J3:P の範囲のデータ形式に合わせる
       const mockValues = [
-        [new Date('2024/03/01'), '09:00', '17:30', 'WEB開発', 'コーディング', 'タスク1']  // ヘッダー行なし
+        [new Date('2024/03/01'), '09:00', '17:30', 'WEB開発', 'コーディング', '', 'タスク1']  // ヘッダー行なし
       ];
       vi.mocked(mockAdapter.getValues).mockReturnValue(mockValues);
 
       const result = repository.findAll();
       expect(result.entries).toHaveLength(1);
-      expect(result.entries[0].description).toBe('タスク1');
+      expect(result.entries[0].workContent).toBe('タスク1');
     });
   });
 }); 

--- a/scripts/workTimeTotals/test/infrastructure/SpreadsheetAdapter.test.ts
+++ b/scripts/workTimeTotals/test/infrastructure/SpreadsheetAdapter.test.ts
@@ -64,10 +64,11 @@ describe('SpreadsheetAdapter', () => {
       expect(result.entries[0].endTime).toBe('12:00');
       expect(result.entries[0].mainCategory).toBe('学習');
       expect(result.entries[0].subCategory).toBe('開発');
-      expect(result.entries[0].description).toBe('技術研修');
+      expect(result.entries[0].meeting).toBe('技術研修');
+      expect(result.entries[0].workContent).toBe('');
 
       // 正しい範囲からデータを取得していることを確認
-      expect(mockSheet.getRange).toHaveBeenCalledWith('I3:N');
+      expect(mockSheet.getRange).toHaveBeenCalledWith('J3:P');
     });
 
     it('空の行はスキップされること', () => {
@@ -211,7 +212,8 @@ describe('SpreadsheetAdapter', () => {
         endTime: '12:00',
         mainCategory: '学習',
         subCategory: '開発',
-        description: '技術研修'
+        meeting: '技術研修',
+        workContent: ''
       }));
 
       adapter.writeWorkEntries(collection);
@@ -221,8 +223,8 @@ describe('SpreadsheetAdapter', () => {
 
       // 正しい値が書き込まれたことを確認
       expect(mockSheet.getRange).toHaveBeenCalledTimes(2); // ヘッダーとデータ
-      expect(mockSheet.getRange).toHaveBeenNthCalledWith(1, 1, 1, 1, 6); // ヘッダー
-      expect(mockSheet.getRange).toHaveBeenNthCalledWith(2, 2, 1, 1, 6); // データ
+      expect(mockSheet.getRange).toHaveBeenNthCalledWith(1, 1, 1, 1, 7); // ヘッダー
+      expect(mockSheet.getRange).toHaveBeenNthCalledWith(2, 2, 1, 1, 7); // データ
     });
 
     it('空のコレクションの場合はヘッダーのみ書き込むこと', () => {
@@ -247,7 +249,7 @@ describe('SpreadsheetAdapter', () => {
 
       // ヘッダーのみ書き込まれたことを確認
       expect(mockSheet.getRange).toHaveBeenCalledTimes(1);
-      expect(mockSheet.getRange).toHaveBeenCalledWith(1, 1, 1, 6);
+      expect(mockSheet.getRange).toHaveBeenCalledWith(1, 1, 1, 7);
     });
   });
 }); 


### PR DESCRIPTION
MTG列の追加に対応したシート構造に変更しました。
勤怠表を新しい構造にして、[個別の開発環境](https://docs.google.com/spreadsheets/d/1b1Rans6onGFC37BA9ylfhkKjfC6weHg26o3VTBg7AsU/edit?gid=2052069152#gid=2052069152)で集計機能が動くことを確認しました。 
