### PR TITLE
集計範囲外であれば、欠けたデータ（カテゴリが空欄等）を許容する

### DIFF
--- a/scripts/workTimeTotals/src/application/WorktimeCollectionService.ts
+++ b/scripts/workTimeTotals/src/application/WorktimeCollectionService.ts
@@ -14,20 +14,18 @@ export class WorktimeCollectionService {
   private getTargetDateSheets(spreadsheetId: string, startDate: Date, endDate: Date): string[] {
     const adapter = new SpreadsheetAdapter(spreadsheetId, '');
     const sheetNames = adapter.getSheetNames();
-    const datePattern = /^\d{8}$/;  // 8桁の数字のみ
+    const datePattern = /^\d{4}(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01])$/;  // YYYYMMDDの形式のみ
 
     return sheetNames.filter(name => {
-      // 数字以外の文字を削除
-      const numbersOnly = name.replace(/\D/g, '');
-      // 8桁の数字でない場合はスキップ
-      if (!datePattern.test(numbersOnly)) {
+      // YYYYMMDDの形式でない場合はスキップ
+      if (!datePattern.test(name)) {
         return false;
       }
 
-      // シート名から日付を取得
-      const year = parseInt(numbersOnly.substring(0, 4));
-      const month = parseInt(numbersOnly.substring(4, 6)) - 1;
-      const day = parseInt(numbersOnly.substring(6, 8));
+      // シート名から日付を取得（すでにYYYYMMDD形式であることは確認済み）
+      const year = parseInt(name.substring(0, 4));
+      const month = parseInt(name.substring(4, 6)) - 1;
+      const day = parseInt(name.substring(6, 8));
       const sheetDate = new Date(year, month, day);
 
       // 日付文字列に変換して比較

--- a/scripts/workTimeTotals/src/domain/dashboard/DashboardRepository.ts
+++ b/scripts/workTimeTotals/src/domain/dashboard/DashboardRepository.ts
@@ -47,39 +47,6 @@ export class DashboardRepository {
     }
   }
 
-  /**
-   * ダッシュボードシートを初期化（存在しない場合は作成）
-   */
-  initializeSheet(): void {
-    try {
-      const spreadsheet = SpreadsheetApp.openById(this.spreadsheetId);
-      let sheet = spreadsheet.getSheetByName(TOTALING_SHEET.SHEET_NAME.DASHBOARD);
-
-      if (!sheet) {
-        sheet = spreadsheet.insertSheet(TOTALING_SHEET.SHEET_NAME.DASHBOARD);
-        
-        // ヘッダーの設定
-        sheet.getRange('A1').setValue('集計開始日');
-        sheet.getRange('B1').setValue('集計終了日');
-        sheet.getRange('C1').setValue('案件選択');
-
-        // 書式の設定
-        sheet.getRange('A2:B2').setNumberFormat('yyyy/mm/dd');
-        
-        // 列幅の調整
-        sheet.setColumnWidth(1, 120);
-        sheet.setColumnWidth(2, 120);
-        sheet.setColumnWidth(3, 300);
-      }
-    } catch (error) {
-      throw new WorktimeError(
-        'Failed to initialize dashboard sheet',
-        ErrorCodes.DASHBOARD_ERROR,
-        { message: error instanceof Error ? error.message : '不明なエラー' }
-      );
-    }
-  }
-
   private getSheet(): GoogleAppsScript.Spreadsheet.Sheet {
     const spreadsheet = SpreadsheetApp.openById(this.spreadsheetId);
     const sheet = spreadsheet.getSheetByName(TOTALING_SHEET.SHEET_NAME.DASHBOARD);

--- a/scripts/workTimeTotals/src/main.ts
+++ b/scripts/workTimeTotals/src/main.ts
@@ -209,14 +209,3 @@ function main() {
     }
   }
 }
-
-// ダッシュボードシートの初期化用関数
-function initializeDashboard() {
-  try {
-    const dashboardRepo = new DashboardRepository(TOTALING_SHEET.SS_ID);
-    dashboardRepo.initializeSheet();
-    console.log('ダッシュボードシートを初期化しました');
-  } catch (error) {
-    console.error('ダッシュボードシートの初期化に失敗しました:', error);
-  }
-}


### PR DESCRIPTION
対応しました。
合わせて、シート名がYYYYMMDD形式以外のものは全て弾くようにしました。元々は8桁の数字が含まれていたらというロジックだったためです。
（ _20250401 のようなシート名は見ないようにした。）