### PR TITLE
案件別とチーム集計を選択できるようにする

### DIFF
--- a/scripts/workTimeTotals/.env.sample
+++ b/scripts/workTimeTotals/.env.sample
@@ -1,4 +1,2 @@
 # 対象スクリプトのID
 SCRIPT_ID=XXXXXXX
-# 対象スプレッドシートのID
-SPREADSHEET_ID=XXXXXXX

--- a/scripts/workTimeTotals/src/define.ts
+++ b/scripts/workTimeTotals/src/define.ts
@@ -24,7 +24,9 @@ export const TOTALING_SHEET = {
     DASHBOARD: {
       START_DATE: 'A2',
       END_DATE: 'B2',
-      PROJECTS: 'C2'
+      PROJECTS: 'C2',
+      OUTPUT_OVERTIME_AND_CATEGORY: 'B5', // 残業時間と業務比率の出力チェックボックス
+      OUTPUT_PROJECT_BREAKDOWN: 'B6'      // 案件別作業時間の内訳の出力チェックボックス
     }
   }
 } as const;

--- a/scripts/workTimeTotals/src/define.ts
+++ b/scripts/workTimeTotals/src/define.ts
@@ -1,6 +1,6 @@
 // NOTE: 内容未調整
 export const TOTALING_SHEET = {
-  SS_ID: import.meta.env.VITE_SS_ID_TOTALING_SHEET,
+  SS_ID: SpreadsheetApp.getActiveSpreadsheet().getId(),
   SHEET_NAME: {
     EMPLOYEE_LIST: '棚卸しシートリスト',
     WORK_ENTRIES: 'WorkEntries',

--- a/scripts/workTimeTotals/src/domain/dashboard/DashboardRepository.ts
+++ b/scripts/workTimeTotals/src/domain/dashboard/DashboardRepository.ts
@@ -22,6 +22,10 @@ export class DashboardRepository {
       // プロジェクトリストの取得
       const projectsValue = sheet.getRange(TOTALING_SHEET.COLUMNS.DASHBOARD.PROJECTS).getValue();
       
+      // 出力選択チェックボックスの取得
+      const outputOvertimeAndCategoryValue = sheet.getRange(TOTALING_SHEET.COLUMNS.DASHBOARD.OUTPUT_OVERTIME_AND_CATEGORY).getValue();
+      const outputProjectBreakdownValue = sheet.getRange(TOTALING_SHEET.COLUMNS.DASHBOARD.OUTPUT_PROJECT_BREAKDOWN).getValue();
+      
       // 日付の変換
       const startDate = dayjsLib.parse(startDateValue).toDate();
       const endDate = dayjsLib.parse(endDateValue).toDate();
@@ -33,10 +37,16 @@ export class DashboardRepository {
         .map(project => project.trim())
         .filter(project => project !== '');
 
+      // チェックボックスの値をブール値に変換（チェックボックスはtrueまたはfalseで返されるが、念のため変換）
+      const outputOvertimeAndCategory = Boolean(outputOvertimeAndCategoryValue);
+      const outputProjectBreakdown = Boolean(outputProjectBreakdownValue);
+
       return {
         startDate,
         endDate,
-        targetProjects
+        targetProjects,
+        outputOvertimeAndCategory,
+        outputProjectBreakdown
       };
     } catch (error) {
       throw new WorktimeError(

--- a/scripts/workTimeTotals/src/domain/dashboard/DashboardSettings.ts
+++ b/scripts/workTimeTotals/src/domain/dashboard/DashboardSettings.ts
@@ -2,4 +2,6 @@ export interface DashboardSettings {
   startDate: Date;
   endDate: Date;
   targetProjects: string[];
+  outputOvertimeAndCategory: boolean; // 残業時間と業務比率の出力フラグ
+  outputProjectBreakdown: boolean;    // 案件別作業時間の内訳の出力フラグ
 } 

--- a/scripts/workTimeTotals/src/presentation/error/ErrorModalPresenter.ts
+++ b/scripts/workTimeTotals/src/presentation/error/ErrorModalPresenter.ts
@@ -48,4 +48,33 @@ export class ErrorModalPresenter {
       ui.alert('エラー', message, ui.ButtonSet.OK);
     }
   }
+
+  /**
+   * 警告メッセージをモーダルダイアログで表示
+   * @param title モーダルのタイトル
+   * @param message 表示するメッセージ
+   * @param spreadsheetId 関連するスプレッドシートのID（オプション）
+   */
+  static showWarning(title: string, message: string, spreadsheetId?: string): void {
+    const ui = SpreadsheetApp.getUi();
+    
+    if (spreadsheetId) {
+      const spreadsheetUrl = `https://docs.google.com/spreadsheets/d/${spreadsheetId}/edit`;
+      const htmlOutput = HtmlService
+        .createHtmlOutput(
+          `<p style="font-family: Arial, sans-serif;">
+            ${message.replace(/\n/g, '<br>')}
+            <br><br>
+            <a href="${spreadsheetUrl}" target="_blank">ダッシュボードを開く</a>
+           </p>`
+        )
+        .setSandboxMode(HtmlService.SandboxMode.IFRAME)
+        .setWidth(400)
+        .setHeight(200);
+
+      ui.showModalDialog(htmlOutput, title);
+    } else {
+      ui.alert(title, message, ui.ButtonSet.OK);
+    }
+  }
 } 

--- a/scripts/workTimeTotals/src/presentation/visualization/services/WorktimeVisualizationService.ts
+++ b/scripts/workTimeTotals/src/presentation/visualization/services/WorktimeVisualizationService.ts
@@ -6,6 +6,8 @@ import { OvertimeSummary } from '../../../application/OvertimeCalculationService
 import { SubCategoryVisualizationService } from './SubCategoryVisualizationService';
 
 export class WorktimeVisualizationService {
+  private overtimeVisualized: boolean = false;
+
   constructor(
     private spreadsheetId: string,
     private overtimeVisualizationService: OvertimeVisualizationService,
@@ -29,6 +31,9 @@ export class WorktimeVisualizationService {
         overtimeSheet,
         lastRowOvertime + 2
       );
+      
+      // 残業時間が可視化されたことを記録
+      this.overtimeVisualized = true;
     } catch (error) {
       const details = error instanceof WorktimeError ? {
         ...error.details,
@@ -48,7 +53,10 @@ export class WorktimeVisualizationService {
   // サブカテゴリ別の出力
   visualizeProjectBreakdown(entries: Map<string, WorkEntry[]>): void {
     try {
-      const subCategorySheet = this.createSheet('案件別', 4);
+      // 残業時間が可視化されていない場合はインデックスを3に、そうでなければ4に設定
+      const insertPosition = this.overtimeVisualized ? 4 : 3;
+      
+      const subCategorySheet = this.createSheet('案件別', insertPosition);
       this.subCategoryVisualizationService.visualize(
         entries,
         subCategorySheet


### PR DESCRIPTION
- 残業時間と業務比率、案件別作業時間内訳の出力をダッシュボードから選択可能に
- 出力選択チェックボックスフィールドをダッシュボードに追加
- 未選択時には警告モーダルを表示してユーザーに通知
- 選択されたレポートのみを出力するよう処理を分岐

<img width="911" alt="スクリーンショット 2025-04-18 18 04 35" src="https://github.com/user-attachments/assets/9d4b3325-2c0c-4d0e-a2df-248ec3721737" />

<img width="523" alt="スクリーンショット 2025-04-18 18 04 47" src="https://github.com/user-attachments/assets/077fa5be-f0f5-4c4b-abaa-a8418da399b1" />
